### PR TITLE
Fixed the Bot class name and introduced BotBuilder class

### DIFF
--- a/docs/getting-started/01-installation.md
+++ b/docs/getting-started/01-installation.md
@@ -13,7 +13,12 @@ This package can be installed via composer:
 
 To be able to interact with Telegram servers you need to create an instance and pass your Telegram Bot API Token:
 ```php
-$bot = new \Telepath\TelegramBot('your api token');
+$bot = new \Telepath\Bot('your api token');
+```
+You can also use the `BotBuilder` class to obtain an instance of the `Bot` class.
+
+```php
+$bot = \Telepath\BotBuilder::token('your api token')->build();
 ```
 
 That's already enough to send messages and other media.
@@ -21,10 +26,18 @@ That's already enough to send messages and other media.
 ### Custom Telegram Bot API Server
 
 If you're using a custom Telegram Bot API Server, you need to pass the URL as an additional parameter to the constructor
-of TelegramBot.
+of `Bot`.
 
 ```php
-$bot = new \Telepath\TelegramBot('your api token', baseUri: 'http://127.0.0.1:8081');
+$bot = new \Telepath\Bot('your api token', baseUri: 'http://127.0.0.1:8081');
+```
+
+When using the `BotBuilder` class, pass the URL as follows:
+
+```php
+$bot = \Telepath\BotBuilder::token('your api token')
+    ->baseUri('http://127.0.0.1:8081')
+    ->build();
 ```
 
 :::caution Important

--- a/docs/getting-started/01-installation.md
+++ b/docs/getting-started/01-installation.md
@@ -29,14 +29,14 @@ If you're using a custom Telegram Bot API Server, you need to pass the URL as an
 of `Bot`.
 
 ```php
-$bot = new \Telepath\Bot('your api token', baseUri: 'http://127.0.0.1:8081');
+$bot = new \Telepath\Bot('your api token', apiServerUrl: 'http://127.0.0.1:8081');
 ```
 
 When using the `BotBuilder` class, pass the URL as follows:
 
 ```php
 $bot = \Telepath\BotBuilder::token('your api token')
-    ->baseUri('http://127.0.0.1:8081')
+    ->apiServerUrl('http://127.0.0.1:8081')
     ->build();
 ```
 

--- a/docs/getting-started/02-laravel.md
+++ b/docs/getting-started/02-laravel.md
@@ -21,18 +21,18 @@ The service provider for your Laravel project automatically gets installed and p
 
 ## Usage
 
-Wherever you need to call a Telegram Bot API method, you can get the Bot instance via Telegrams Service Container. 
+Wherever you need to call a Telegram Bot API method, you can get the `Bot` instance via Telegrams Service Container. 
 
 ```php
-$bot = resolve(\Telepath\TelegramBot::class);
+$bot = resolve(\Telepath\Bot::class);
 ```
 
-This means you can make use of autowiring and request the instance via the __construct method in most places like in 
+This means you can make use of autowiring and request the instance via the `__construct` method in most places like in 
 this example with constructor properties:
 
 ```php
 public function __construct(
-    protected TelegramBot $bot
+    protected Bot $bot
 ) {}
 ```
 
@@ -65,4 +65,4 @@ If you wish to make modifications to the bundled config or routes file you can p
 
 `php artisan vendor:publish`
 
-Select the corresponding telepath-config or telepath-routes tag or alternatively the TelepathServiceProvider for both files.
+Select the corresponding `telepath-config` or `telepath-routes` tag or alternatively the TelepathServiceProvider for both files.

--- a/docs/usage/02-handlers.md
+++ b/docs/usage/02-handlers.md
@@ -88,12 +88,12 @@ namespace App\Telegram\Handlers;
 
 use Telepath\Handlers\Handler;
 use Telepath\Telegram\Update;
-use Telepath\TelegramBot;
+use Telepath\Bot;
 
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Greeting extends Handler
 {
-    public function responsible(TelegramBot $bot, Update $update): bool
+    public function responsible(Bot $bot, Update $update): bool
     {
         if ($update->message?->text === null)
         {

--- a/docs/usage/03-conversations.md
+++ b/docs/usage/03-conversations.md
@@ -7,7 +7,7 @@ But for this to work, we need a CachingInterface.
 
 ## Setup
 
-The `TelegramBot` class has an `enableCaching` method that takes every PSR-6 or PSR-16 compatible CacheInterface.
+The `Bot` class has an `enableCaching` method that takes every PSR-6 or PSR-16 compatible CacheInterface.
 
 :::tip Pro Tip
 We recommend using the [Symfony Cache Component](https://symfony.com/doc/current/components/cache.html) since it has a 


### PR DESCRIPTION
Fixed the Bot class name from `TelegramBot` to `Bot` and introduced the `BotBuilder` class to the documentation.